### PR TITLE
Feature/search animals

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -4,7 +4,13 @@
 CREATE DATABASE IF NOT EXISTS adoption_db;
 USE adoption_db;
 
-DROP TABLE IF EXISTS adoption_user;
+DROP TABLE IF EXISTS adoption_user CASCADE;
+DROP TABLE IF EXISTS animal_favorite CASCADE;
+DROP TABLE IF EXISTS post CASCADE;
+DROP TABLE IF EXISTS photo CASCADE;
+DROP TABLE IF EXISTS animal CASCADE;
+DROP TABLE IF EXISTS breed CASCADE;
+DROP TABLE IF EXISTS adoption_user CASCADE;
 
 CREATE TABLE adoption_user (
     id_user       SERIAL PRIMARY KEY,
@@ -32,6 +38,15 @@ ALTER TABLE adoption_user ADD CONSTRAINT ck_user_firstname CHECK (first_name <> 
 ALTER TABLE adoption_user ADD CONSTRAINT ck_user_lastname  CHECK (last_name <> '');
 ALTER TABLE adoption_user ADD CONSTRAINT ck_user_gender    CHECK (gender IN ('male', 'female', 'other', 'prefer_not_to_say'));
 ALTER TABLE adoption_user ADD CONSTRAINT ck_user_phone     CHECK (phone_number ~ '^\+?[0-9]{7,15}$');
+
+-- 1. Quitar la obligación de tener un valor (NOT NULL)
+ALTER TABLE adoption_user ALTER COLUMN gender DROP NOT NULL;
+ALTER TABLE adoption_user ALTER COLUMN birth_date DROP NOT NULL;
+
+-- 2. Quitar las restricciones de validación que fallan con nulos
+ALTER TABLE adoption_user DROP CONSTRAINT ck_user_gender;
+ALTER TABLE adoption_user DROP CONSTRAINT ck_user_birthdate;
+ALTER TABLE adoption_user DROP CONSTRAINT ck_user_max_age;
 
 -- adoption_user stores every registered person on the platform.
 -- Any user can act as publisher (post animals) or adopter (mark favorites),

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -40,13 +40,13 @@ ALTER TABLE adoption_user ADD CONSTRAINT ck_user_gender    CHECK (gender IN ('ma
 ALTER TABLE adoption_user ADD CONSTRAINT ck_user_phone     CHECK (phone_number ~ '^\+?[0-9]{7,15}$');
 
 -- 1. Quitar la obligación de tener un valor (NOT NULL)
-ALTER TABLE adoption_user ALTER COLUMN gender DROP NOT NULL;
-ALTER TABLE adoption_user ALTER COLUMN birth_date DROP NOT NULL;
+-- ALTER TABLE adoption_user ALTER COLUMN gender DROP NOT NULL;
+-- ALTER TABLE adoption_user ALTER COLUMN birth_date DROP NOT NULL;
 
 -- 2. Quitar las restricciones de validación que fallan con nulos
-ALTER TABLE adoption_user DROP CONSTRAINT ck_user_gender;
-ALTER TABLE adoption_user DROP CONSTRAINT ck_user_birthdate;
-ALTER TABLE adoption_user DROP CONSTRAINT ck_user_max_age;
+-- ALTER TABLE adoption_user DROP CONSTRAINT ck_user_gender;
+-- ALTER TABLE adoption_user DROP CONSTRAINT ck_user_birthdate;
+-- ALTER TABLE adoption_user DROP CONSTRAINT ck_user_max_age;
 
 -- adoption_user stores every registered person on the platform.
 -- Any user can act as publisher (post animals) or adopter (mark favorites),

--- a/src/main/kotlin/com/nullpointercats/sys/adopta/animal/controllers/AnimalController.kt
+++ b/src/main/kotlin/com/nullpointercats/sys/adopta/animal/controllers/AnimalController.kt
@@ -3,8 +3,10 @@ package com.nullpointercats.sys.adopta.animal.controllers
 import com.nullpointercats.sys.adopta.animal.domain.Animal
 import com.nullpointercats.sys.adopta.animal.domain.toDomain
 import com.nullpointercats.sys.adopta.animal.domain.toResponse
+import com.nullpointercats.sys.adopta.animal.domain.toSearchResponse
 import com.nullpointercats.sys.adopta.animal.dto.request.AnimalRegisterRequest
 import com.nullpointercats.sys.adopta.animal.dto.response.AnimalRegisterResponse
+import com.nullpointercats.sys.adopta.animal.dto.response.AnimalSearchResponse
 import com.nullpointercats.sys.adopta.animal.services.AnimalService
 import com.nullpointercats.sys.adopta.user.domain.User
 import com.nullpointercats.sys.adopta.user.services.UserService
@@ -18,6 +20,8 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.GetMapping       
+import org.springframework.web.bind.annotation.RequestParam    
 import kotlin.jvm.java
 
 /**
@@ -93,5 +97,5 @@ class AnimalController {
         logger.info("[GET /animals] [SUCCESS] ${results.size} animals found")
         return ResponseEntity.ok(results)
     }
-    
+
 }

--- a/src/main/kotlin/com/nullpointercats/sys/adopta/animal/controllers/AnimalController.kt
+++ b/src/main/kotlin/com/nullpointercats/sys/adopta/animal/controllers/AnimalController.kt
@@ -83,16 +83,16 @@ class AnimalController {
         @RequestParam(required = false) species: String?,
         @RequestParam(required = false) size: String?,
         @RequestParam(required = false) zipcode: String?,
-        @RequestParam(required = false) breedId: Int?,
+        @RequestParam(required = false) breedName: String?,
         @RequestAttribute("authenticatedUser") userFound: User
     ): ResponseEntity<List<AnimalSearchResponse>> {
         
         logger.info(
             "[GET /animals] [ATTEMPT] From ${userFound.email} " +
-            "— species=$species size=$size zipcode=$zipcode breedId=$breedId"
+            "— species=$species size=$size zipcode=$zipcode breedName=$breedName"
             )
             
-        val results = animalService.searchAnimals(species, size, zipcode, breedId).map { it.toSearchResponse() }
+        val results = animalService.searchAnimals(species, size, zipcode, breedName).map { it.toSearchResponse() }
         
         logger.info("[GET /animals] [SUCCESS] ${results.size} animals found")
         return ResponseEntity.ok(results)

--- a/src/main/kotlin/com/nullpointercats/sys/adopta/animal/controllers/AnimalController.kt
+++ b/src/main/kotlin/com/nullpointercats/sys/adopta/animal/controllers/AnimalController.kt
@@ -60,4 +60,38 @@ class AnimalController {
         logger.info("[animals/register] [SUCCESS] Animal registered successfully ")
         return ResponseEntity.ok(animalSaved.toResponse())
     }
+    
+    /**
+    * Endpoint to search animals available for adoption using optional filters.
+    *
+    * URL:    GET http://localhost:8080/animals
+    * Params (all optional):
+    *   species  → DOG | CAT
+    *   size     → small | medium | large | extra_large
+    *   zipcode  → e.g. 06600
+    *   breedId  → numeric breed ID
+    *
+    * Returns an empty list when no animals match — never 404.
+    */
+    
+    @GetMapping
+    fun searchAnimals(
+        @RequestParam(required = false) species: String?,
+        @RequestParam(required = false) size: String?,
+        @RequestParam(required = false) zipcode: String?,
+        @RequestParam(required = false) breedId: Int?,
+        @RequestAttribute("authenticatedUser") userFound: User
+    ): ResponseEntity<List<AnimalSearchResponse>> {
+        
+        logger.info(
+            "[GET /animals] [ATTEMPT] From ${userFound.email} " +
+            "— species=$species size=$size zipcode=$zipcode breedId=$breedId"
+            )
+            
+        val results = animalService.searchAnimals(species, size, zipcode, breedId).map { it.toSearchResponse() }
+        
+        logger.info("[GET /animals] [SUCCESS] ${results.size} animals found")
+        return ResponseEntity.ok(results)
+    }
+    
 }

--- a/src/main/kotlin/com/nullpointercats/sys/adopta/animal/domain/AnimalEF.kt
+++ b/src/main/kotlin/com/nullpointercats/sys/adopta/animal/domain/AnimalEF.kt
@@ -1,6 +1,7 @@
 package com.nullpointercats.sys.adopta.animal.domain
 import com.nullpointercats.sys.adopta.animal.dto.request.AnimalRegisterRequest
 import com.nullpointercats.sys.adopta.animal.dto.response.AnimalRegisterResponse
+import com.nullpointercats.sys.adopta.animal.dto.response.AnimalSearchResponse
 import com.nullpointercats.sys.adopta.animal.entities.AnimalEntity
 import com.nullpointercats.sys.adopta.user.domain.*
 import java.time.LocalDate
@@ -61,4 +62,20 @@ fun AnimalEntity.toDomain(): Animal {
         photos = this.photos.map { photoEntity -> photoEntity.toDomain() }
 
     )
+
+fun Animal.toSearchResponse(): AnimalSearchResponse {
+    return AnimalSearchResponse(
+        idAnimal      = this.idAnimal,
+        animalName    = this.animalName,
+        species       = this.species,
+        size          = this.size,
+        description   = this.description,
+        dateOfBirth   = this.dateOfBirth,
+        animalZipcode = this.animalZipcode,
+        publishedAt   = this.publishedAt,
+        breedName     = this.breed?.breedName,
+        photos        = this.photos.map { it.url }
+    )
+}
+
 }

--- a/src/main/kotlin/com/nullpointercats/sys/adopta/animal/domain/AnimalEF.kt
+++ b/src/main/kotlin/com/nullpointercats/sys/adopta/animal/domain/AnimalEF.kt
@@ -62,6 +62,7 @@ fun AnimalEntity.toDomain(): Animal {
         photos = this.photos.map { photoEntity -> photoEntity.toDomain() }
 
     )
+}
 
 fun Animal.toSearchResponse(): AnimalSearchResponse {
     return AnimalSearchResponse(
@@ -78,4 +79,3 @@ fun Animal.toSearchResponse(): AnimalSearchResponse {
     )
 }
 
-}

--- a/src/main/kotlin/com/nullpointercats/sys/adopta/animal/dto/response/AnimalSearchResponse.kt
+++ b/src/main/kotlin/com/nullpointercats/sys/adopta/animal/dto/response/AnimalSearchResponse.kt
@@ -1,0 +1,21 @@
+package com.nullpointercats.sys.adopta.animal.dto.response
+
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+/**
+ * DTO representing the response sent back to the client
+ * after a search query for animals available for adoption.
+ */
+data class AnimalSearchResponse(
+    val idAnimal: Int?,
+    val animalName: String,
+    val species: String,
+    val size: String?,
+    val description: String?,
+    val dateOfBirth: LocalDate?,
+    val animalZipcode: String,
+    val publishedAt: LocalDateTime?,
+    val breedName: String?,
+    val photos: List<String>
+)

--- a/src/main/kotlin/com/nullpointercats/sys/adopta/animal/repositories/AnimalRepository.kt
+++ b/src/main/kotlin/com/nullpointercats/sys/adopta/animal/repositories/AnimalRepository.kt
@@ -7,4 +7,21 @@ import org.springframework.data.repository.CrudRepository
  * Data Repository for managing [AnimalEntity] persistence.
  */
 interface AnimalRepository : CrudRepository<AnimalEntity, Int> {
+    @Query("""
+        SELECT DISTINCT a
+        FROM AnimalEntity a
+        LEFT JOIN FETCH a.breed b
+        LEFT JOIN FETCH a.photos p
+        WHERE (:species IS NULL OR a.species       = :species)
+          AND (:size    IS NULL OR a.size          = :size)
+          AND (:zipcode IS NULL OR a.animalZipcode = :zipcode)
+          AND (:breedId IS NULL OR b.idBreed       = :breedId)
+        ORDER BY a.publishedAt DESC
+    """)
+    fun findByFilters(
+        @Param("species") species: String?,
+        @Param("size")    size: String?,
+        @Param("zipcode") zipcode: String?,
+        @Param("breedId") breedId: Int?
+    ): List<AnimalEntity>
 }

--- a/src/main/kotlin/com/nullpointercats/sys/adopta/animal/repositories/AnimalRepository.kt
+++ b/src/main/kotlin/com/nullpointercats/sys/adopta/animal/repositories/AnimalRepository.kt
@@ -17,13 +17,13 @@ interface AnimalRepository : CrudRepository<AnimalEntity, Int> {
         WHERE (:species IS NULL OR a.species       = :species)
           AND (:size    IS NULL OR a.size          = :size)
           AND (:zipcode IS NULL OR a.animalZipcode = :zipcode)
-          AND (:breedId IS NULL OR b.idBreed       = :breedId)
-        ORDER BY a.publishedAt DESC
+          AND (:breedName IS NULL OR LOWER(b.breedName) LIKE LOWER(CONCAT('%', :breedName, '%')))
+          ORDER BY a.publishedAt DESC
     """)
     fun findByFilters(
         @Param("species") species: String?,
         @Param("size")    size: String?,
         @Param("zipcode") zipcode: String?,
-        @Param("breedId") breedId: Int?
+        @Param("breedName") breedName: String?
     ): List<AnimalEntity>
 }

--- a/src/main/kotlin/com/nullpointercats/sys/adopta/animal/repositories/AnimalRepository.kt
+++ b/src/main/kotlin/com/nullpointercats/sys/adopta/animal/repositories/AnimalRepository.kt
@@ -1,6 +1,8 @@
 package com.nullpointercats.sys.adopta.animal.repositories
 
 import com.nullpointercats.sys.adopta.animal.entities.AnimalEntity
+import org.springframework.data.jpa.repository.Query 
+import org.springframework.data.repository.query.Param
 import org.springframework.data.repository.CrudRepository
 
 /**

--- a/src/main/kotlin/com/nullpointercats/sys/adopta/animal/repositories/AnimalRepository.kt
+++ b/src/main/kotlin/com/nullpointercats/sys/adopta/animal/repositories/AnimalRepository.kt
@@ -1,29 +1,26 @@
 package com.nullpointercats.sys.adopta.animal.repositories
 
 import com.nullpointercats.sys.adopta.animal.entities.AnimalEntity
-import org.springframework.data.jpa.repository.Query 
-import org.springframework.data.repository.query.Param
+import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.CrudRepository
+import org.springframework.data.repository.query.Param
 
-/**
- * Data Repository for managing [AnimalEntity] persistence.
- */
 interface AnimalRepository : CrudRepository<AnimalEntity, Int> {
-    @Query("""
-        SELECT DISTINCT a
-        FROM AnimalEntity a
-        LEFT JOIN FETCH a.breed b
-        LEFT JOIN FETCH a.photos p
-        WHERE (:species IS NULL OR a.species       = :species)
-          AND (:size    IS NULL OR a.size          = :size)
-          AND (:zipcode IS NULL OR a.animalZipcode = :zipcode)
-          AND (:breedName IS NULL OR LOWER(b.breedName) LIKE LOWER(CONCAT('%', :breedName, '%')))
-          ORDER BY a.publishedAt DESC
-    """)
+
+    @Query(value = """
+        SELECT DISTINCT a.* 
+        FROM animal a
+        LEFT JOIN breed b ON b.id_breed = a.id_breed
+        WHERE (:species   IS NULL OR a.species        = :species)
+          AND (:size      IS NULL OR a.size           = :size)
+          AND (:zipcode   IS NULL OR a.animal_zipcode = :zipcode)
+          AND (:breedName IS NULL OR (b.id_breed IS NOT NULL AND lower(b.breed_name) LIKE lower(('%' || :breedName || '%'))))
+        ORDER BY a.published_at DESC
+    """, nativeQuery = true)
     fun findByFilters(
-        @Param("species") species: String?,
-        @Param("size")    size: String?,
-        @Param("zipcode") zipcode: String?,
+        @Param("species")   species: String?,
+        @Param("size")      size: String?,
+        @Param("zipcode")   zipcode: String?,
         @Param("breedName") breedName: String?
     ): List<AnimalEntity>
 }

--- a/src/main/kotlin/com/nullpointercats/sys/adopta/animal/services/AnimalService.kt
+++ b/src/main/kotlin/com/nullpointercats/sys/adopta/animal/services/AnimalService.kt
@@ -74,7 +74,7 @@ class AnimalService {
         
         val normalizedSpecies = species?.uppercase()?.trim()
         val normalizedSize    = size?.lowercase()?.trim()
-        val normalizedBreedName = breedName?.trim() 
+        val normalizedBreedName = breedName?.lowercase()?.trim() 
         
         logger.info("Searching animals — species=$normalizedSpecies size=$normalizedSize zipcode=$zipcode breedName=$normalizedBreedName")
         

--- a/src/main/kotlin/com/nullpointercats/sys/adopta/animal/services/AnimalService.kt
+++ b/src/main/kotlin/com/nullpointercats/sys/adopta/animal/services/AnimalService.kt
@@ -57,5 +57,25 @@ class AnimalService {
         }
 
     }
+    
+    /**
+     * * Retrieves a filtered list of animals available for adoption.
+     *
+     * * All filter parameters are optional.
+     * * Allowed values enforced by the DB:
+     * *   species → "DOG" | "CAT"
+     * *   size    → "small" | "medium" | "large" | "extra_large"
+    **/
+    
+    fun searchAnimals(species: String?,size: String?, zipcode: String?, breedId: Int?
+    ): List<Animal> {
+        
+        val normalizedSpecies = species?.uppercase()?.trim()
+        val normalizedSize    = size?.lowercase()?.trim()
+        
+        logger.info("Searching animals — species=$normalizedSpecies size=$normalizedSize zipcode=$zipcode breedId=$breedId")
+        
+        return animalRepository.findByFilters(normalizedSpecies, normalizedSize, zipcode, breedId).map { it.toDomain() }
+}
 
 }

--- a/src/main/kotlin/com/nullpointercats/sys/adopta/animal/services/AnimalService.kt
+++ b/src/main/kotlin/com/nullpointercats/sys/adopta/animal/services/AnimalService.kt
@@ -10,6 +10,7 @@ import com.nullpointercats.sys.adopta.user.services.UserService
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 /**
  * Service layer responsible for executing business logic related to animals.
@@ -35,6 +36,7 @@ class AnimalService {
     /**
      * Manage the registration of a new animal.
      */
+    @Transactional
     fun addNewAnimal(animal : Animal, breedId : Int?): Animal ? {
 
         val userEntityOptional = userRepository.findById(animal.publisher.id.toInt())
@@ -67,15 +69,16 @@ class AnimalService {
      * *   size    → "small" | "medium" | "large" | "extra_large"
     **/
     
-    fun searchAnimals(species: String?,size: String?, zipcode: String?, breedId: Int?
+    fun searchAnimals(species: String?,size: String?, zipcode: String?, breedName: String?
     ): List<Animal> {
         
         val normalizedSpecies = species?.uppercase()?.trim()
         val normalizedSize    = size?.lowercase()?.trim()
+        val normalizedBreedName = breedName?.trim() 
         
-        logger.info("Searching animals — species=$normalizedSpecies size=$normalizedSize zipcode=$zipcode breedId=$breedId")
+        logger.info("Searching animals — species=$normalizedSpecies size=$normalizedSize zipcode=$zipcode breedName=$normalizedBreedName")
         
-        return animalRepository.findByFilters(normalizedSpecies, normalizedSize, zipcode, breedId).map { it.toDomain() }
+        return animalRepository.findByFilters(normalizedSpecies, normalizedSize, zipcode, normalizedBreedName).map { it.toDomain() }
 }
 
 }


### PR DESCRIPTION
Hi, this PR introduces the **search animals** use case, which allows any authenticated user to retrieve a list of animals available for adoption. The endpoint supports optional query parameter filtering so adopters can narrow down results based on their preferences.

---

### Endpoint

```
GET /animals
Authorization: Bearer <token>
```

All query parameters are optional. When no filters are provided, the endpoint returns all registered animals ordered by most recently published.

---

### Available filters

| Parameter | Type | Allowed values | Example |
|---|---|---|---|
| `species` | String | `DOG`, `CAT` | `?species=DOG` |
| `size` | String | `small`, `medium`, `large`, `extra_large` | `?size=small` |
| `zipcode` | String | Any valid zipcode (5–10 chars) | `?zipcode=06600` |
| `breedName` | String | Any partial or full breed name | `?breedName=golden` |

Filters can be combined freely:
```
GET /animals?species=DOG&size=small&zipcode=06600
GET /animals?species=DOG&breedName=labrador
GET /animals?breedName=golden retriever
```

> `breedName` supports partial, case-insensitive matching. Searching `golden` will match `Golden Retriever`.

---

### Architecture — files added or modified

Following the layered architecture already established in the project:

- **`AnimalSearchResponse.kt`** — new DTO for the search response. Returns breed name and photo URLs already flattened to avoid extra client-side requests.
- **`AnimalEF.kt`** — added `toSearchResponse()` extension function to convert an `Animal` domain object into the response DTO.
- **`AnimalRepository.kt`** — added `findByFilters()` with a JPQL `@Query`. Uses `LEFT JOIN FETCH` on `breed` and `photos` to prevent N+1 queries. The `breedName` filter uses `LIKE LOWER(...)` for case-insensitive partial matching. Null parameters are skipped automatically, making all filters truly optional.
- **`AnimalService.kt`** — added `searchAnimals()`. Normalizes input before querying (`species` uppercased, `size` and `breedName` trimmed) to match the database constraints defined in the schema.
- **`AnimalController.kt`** — added `GET /animals` endpoint. Returns `200 OK` with an empty list `[]` when no animals match the filters — never `404`.
- **`schema.sql`** — added indexes on `species`, `size`, and `animal_zipcode` to support the new filter queries.


### Known limitations

- **No free-text search** — filtering by animal name or description is not supported in this version. A `LIKE`-based or full-text search query would be a separate use case.
- **No age/date range filter** — `dateOfBirth` is stored in the DB but is not exposed as a filter parameter yet. Age is a derived attribute and filtering by range requires additional handling.
- **Single value per filter** — it is not possible to search for `DOG` and `CAT` at the same time, or `small` and `medium` simultaneously. Multi-value filter support would require a different query structure.
- **Zipcode is an exact match** — there is no radius or proximity search. Two animals in neighboring zipcodes will not appear in the same query unless the exact zipcode is shared.
- **Authentication required** — the `AuthInterceptor` already covers all routes, so unauthenticated requests to `GET /animals` will return `401` automatically.

---

### Status
**This feature is still under testing.**