### PR TITLE
Feature/user upload photos

### DIFF
--- a/src/main/kotlin/com/nullpointercats/sys/adopta/animal/controllers/FileUploadController.kt
+++ b/src/main/kotlin/com/nullpointercats/sys/adopta/animal/controllers/FileUploadController.kt
@@ -1,0 +1,60 @@
+package com.nullpointercats.sys.adopta.config
+
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+import org.springframework.web.multipart.MultipartFile
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.util.UUID
+
+@RestController
+@RequestMapping("/photos")
+class FileUploadController {
+
+    @Value("\${file.upload-dir}")
+    lateinit var uploadDir: String
+
+    @PostMapping("/upload")
+    fun uploadPhoto(
+        @RequestParam("file") file: MultipartFile
+    ): ResponseEntity<Map<String, String>> {
+
+        if (file.isEmpty) return ResponseEntity.badRequest().build()
+
+        val allowedTypes = listOf("image/jpeg", "image/png", "image/webp")
+        if (file.contentType !in allowedTypes) {
+            return ResponseEntity.badRequest().body(mapOf("error" to "Only JPG, PNG and WEBP allowed"))
+        }
+
+        val uploadPath = Paths.get(System.getProperty("user.dir"), uploadDir).toAbsolutePath()
+        if (!Files.exists(uploadPath)) Files.createDirectories(uploadPath)
+
+        val extension = file.originalFilename?.substringAfterLast(".") ?: "jpg"
+        val fileName = "${UUID.randomUUID()}.$extension"
+        val filePath = uploadPath.resolve(fileName)
+
+        file.transferTo(filePath.toFile())
+
+        val url = "http://localhost:8080/photos/$fileName"
+        return ResponseEntity.ok(mapOf("url" to url))
+    }
+
+    @GetMapping("/{filename}")
+    fun getPhoto(@PathVariable filename: String, response: HttpServletResponse) {
+        val uploadPath = Paths.get(System.getProperty("user.dir"), uploadDir).toAbsolutePath()
+        val filePath = uploadPath.resolve(filename)
+
+        if (!Files.exists(filePath)) {
+            response.status = 404
+            return
+        }
+
+        val contentType = Files.probeContentType(filePath) ?: "image/jpeg"
+        response.contentType = contentType
+        response.outputStream.use { out ->
+            filePath.toFile().inputStream().use { it.copyTo(out) }
+        }
+    }
+}

--- a/src/main/kotlin/com/nullpointercats/sys/adopta/config/CorsConfig.kt
+++ b/src/main/kotlin/com/nullpointercats/sys/adopta/config/CorsConfig.kt
@@ -38,6 +38,6 @@ class CorsConfig (private val authInterceptor: AuthInterceptor) : WebMvcConfigur
     override fun addInterceptors(registry: InterceptorRegistry) {
         registry.addInterceptor(authInterceptor)
             .addPathPatterns("/**")
-            .excludePathPatterns("/users/login", "/users/register")
+            .excludePathPatterns("/users/login", "/users/register", "/photos/upload","/photos/**")
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,3 +12,6 @@ spring.mail.username=${GMAIL_USER}
 spring.mail.password=${GMAIL_PASSWORD}
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
+
+file.upload-dir=uploads
+spring.web.resources.static-locations=file:${user.dir}/uploads/

--- a/target/classes/application.properties
+++ b/target/classes/application.properties
@@ -12,3 +12,6 @@ spring.mail.username=${GMAIL_USER}
 spring.mail.password=${GMAIL_PASSWORD}
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
+
+file.upload-dir=uploads
+spring.web.resources.static-locations=file:${user.dir}/uploads/


### PR DESCRIPTION
Aquí agregamos que el usaurio pueda subir sus propias fotos. De momento lo estamos manejando de maner local, por lo que se necesita de la carpeta \uploads para poder visualizar las fotos. En caso de no existir, esta se va crear automaticamente. Posteriormente se considerará el cambio a Cloudinary para tenerlos en la nube y que no dependan localemnte. Algunas dudas que tengo:

1. La ubicación del archivo FileUploadController.kt, a mi me pareció lógico ponerlo allí ya que subir fotos de momento solo estamos límitando a subir fotos del animal, es propiedad de este (aunque para user podría servir también para que tuviera una foto de perfil, pero no lo estamos considerando), entonces consideré que en Controllers de Animal estaba bien. 
2. En cuanto a lo implementado anteriormente de los URL's lo deje allí de momento. Ya que si no implicaba cambiar desde la base de datos hasta todos los demás módulos del backend, en nuestra próxima junta les pediré opinión al respecto de si lo dejamos o lo elimino, como nuestra reunión es el jueves de ese día para el sábado me dará tiempo de hacerlo sin problemas. 

:)))